### PR TITLE
[Feature][Refactor] Added Filters to Status page

### DIFF
--- a/src/SALsA_Function/HTMLTemplate/SALsAStatus.html
+++ b/src/SALsA_Function/HTMLTemplate/SALsAStatus.html
@@ -1,0 +1,47 @@
+<style>
+td {
+  font-size: 18px;
+  text-align: center;
+  padding: 5px
+}
+th {
+  text-align: left;
+  font-size: 22px;
+  padding-right: 20px;
+  padding-left: 20px;
+  padding-bottom: 5px;
+  padding-top: 5px;
+}
+thead {
+  font-weight: bold;
+  background-color: #d3d3d3;
+}
+form {
+  margin: 0;
+  top: 50%;
+}
+tr:nth-child(even) {background-color: #f2f2f2;}
+
+__excel-bootstrap-table-filter-style.css__
+</style>
+
+<body>
+  <!-- Load jQuery -->
+  <script src="https://ajax.aspnetcdn.com/ajax/jQuery/jquery-1.12.4.min.js"></script>
+  <script>
+__excel-bootstrap-table-filter-bundle.js__	
+	</script>
+__TABLE_INPUT_PLACEHOLDER__
+  <script>
+    // Use the plugin once the DOM has been loaded.
+    $(function () {
+      // Apply the plugin 
+      $('#table').excelTableFilter();
+    });
+  </script>
+</body>
+<footer>
+  <p>Page generated at : __GENERATED_TIMESTAMP__ (in __LOADDING_TIME__ seconds)</p>
+</footer>
+</html>
+

--- a/src/SALsA_Function/HTMLTemplate/excel-bootstrap-table-filter-bundle/LICENSE
+++ b/src/SALsA_Function/HTMLTemplate/excel-bootstrap-table-filter-bundle/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2017 Chester Carmer
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/src/SALsA_Function/HTMLTemplate/excel-bootstrap-table-filter-bundle/Source
+++ b/src/SALsA_Function/HTMLTemplate/excel-bootstrap-table-filter-bundle/Source
@@ -1,0 +1,1 @@
+Adapted from https://github.com/chestercharles/excel-bootstrap-table-filter/

--- a/src/SALsA_Function/HTMLTemplate/excel-bootstrap-table-filter-bundle/excel-bootstrap-table-filter-bundle.js
+++ b/src/SALsA_Function/HTMLTemplate/excel-bootstrap-table-filter-bundle/excel-bootstrap-table-filter-bundle.js
@@ -1,0 +1,329 @@
+(function ($$1) {
+'use strict';
+
+$$1 = 'default' in $$1 ? $$1['default'] : $$1;
+
+var FilterMenu = function () {
+    function FilterMenu(target, th, column, index, options) {
+        this.options = options;
+        this.th = th;
+        this.column = column;
+        this.index = index;
+        this.tds = target.find('tbody tr td:nth-child(' + (this.column + 1) + ')').toArray();
+    }
+    FilterMenu.prototype.initialize = function () {
+        this.menu = this.dropdownFilterDropdown();
+        this.th.appendChild(this.menu);
+        var $trigger = $(this.menu.children[0]);
+        var $content = $(this.menu.children[1]);
+        var $menu = $(this.menu);
+        $trigger.click(function () {
+            return $content.toggle();
+        });
+        $(document).click(function (el) {
+            if (!$menu.is(el.target) && $menu.has(el.target).length === 0) {
+                $content.hide();
+            }
+        });
+    };
+    FilterMenu.prototype.searchToggle = function (value) {
+        if (this.selectAllCheckbox instanceof HTMLInputElement) this.selectAllCheckbox.checked = false;
+        if (value.length === 0) {
+            this.toggleAll(true);
+            if (this.selectAllCheckbox instanceof HTMLInputElement) this.selectAllCheckbox.checked = true;
+            return;
+        }
+        this.toggleAll(false);
+        this.inputs.filter(function (input) {
+            return input.value.toLowerCase().indexOf(value.toLowerCase()) > -1;
+        }).forEach(function (input) {
+            input.checked = true;
+        });
+    };
+    FilterMenu.prototype.updateSelectAll = function () {
+        if (this.selectAllCheckbox instanceof HTMLInputElement) {
+            $(this.searchFilter).val('');
+            this.selectAllCheckbox.checked = this.inputs.length === this.inputs.filter(function (input) {
+                return input.checked;
+            }).length;
+        }
+    };
+    FilterMenu.prototype.selectAllUpdate = function (checked) {
+        $(this.searchFilter).val('');
+        this.toggleAll(checked);
+    };
+    FilterMenu.prototype.toggleAll = function (checked) {
+        for (var i = 0; i < this.inputs.length; i++) {
+            var input = this.inputs[i];
+            if (input instanceof HTMLInputElement) input.checked = checked;
+        }
+    };
+    FilterMenu.prototype.dropdownFilterItem = function (td, self) {
+        var value = td.innerText;
+        var dropdownFilterItem = document.createElement('div');
+        dropdownFilterItem.className = 'dropdown-filter-item';
+        var input = document.createElement('input');
+        input.type = 'checkbox';
+        input.value = value.trim().replace(/ +(?= )/g, '');
+        input.setAttribute('checked', 'checked');
+        input.className = 'dropdown-filter-menu-item item';
+        input.setAttribute('data-column', self.column.toString());
+        input.setAttribute('data-index', self.index.toString());
+        dropdownFilterItem.appendChild(input);
+        dropdownFilterItem.innerHTML = dropdownFilterItem.innerHTML.trim() + ' ' + value;
+        return dropdownFilterItem;
+    };
+    FilterMenu.prototype.dropdownFilterItemSelectAll = function () {
+        var value = this.options.captions.select_all;
+        var dropdownFilterItemSelectAll = document.createElement('div');
+        dropdownFilterItemSelectAll.className = 'dropdown-filter-item';
+        var input = document.createElement('input');
+        input.type = 'checkbox';
+        input.value = this.options.captions.select_all;
+        input.setAttribute('checked', 'checked');
+        input.className = 'dropdown-filter-menu-item select-all';
+        input.setAttribute('data-column', this.column.toString());
+        input.setAttribute('data-index', this.index.toString());
+        dropdownFilterItemSelectAll.style.fontWeight = "bold";
+        dropdownFilterItemSelectAll.appendChild(input);
+        dropdownFilterItemSelectAll.innerHTML = dropdownFilterItemSelectAll.innerHTML + ' ' + value;
+        return dropdownFilterItemSelectAll;
+    };
+    FilterMenu.prototype.dropdownFilterSearch = function () {
+        var dropdownFilterItem = document.createElement('div');
+        dropdownFilterItem.className = 'dropdown-filter-search';
+        var input = document.createElement('input');
+        input.type = 'text';
+        input.className = 'dropdown-filter-menu-search form-control';
+        input.setAttribute('data-column', this.column.toString());
+        input.setAttribute('data-index', this.index.toString());
+        input.setAttribute('placeholder', this.options.captions.search);
+        dropdownFilterItem.appendChild(input);
+        return dropdownFilterItem;
+    };
+    FilterMenu.prototype.dropdownFilterSort = function (direction) {
+        var dropdownFilterItem = document.createElement('div');
+        dropdownFilterItem.className = 'dropdown-filter-sort';
+        var span = document.createElement('span');
+        span.className = direction.toLowerCase().split(' ').join('-');
+        span.setAttribute('data-column', this.column.toString());
+        span.setAttribute('data-index', this.index.toString());
+        span.innerText = direction;
+        dropdownFilterItem.appendChild(span);
+        return dropdownFilterItem;
+    };
+    FilterMenu.prototype.dropdownFilterContent = function () {
+        var _this = this;
+        var self = this;
+        var dropdownFilterContent = document.createElement('div');
+        dropdownFilterContent.className = 'dropdown-filter-content';
+        var innerDivs = this.tds.reduce(function (arr, el) {
+            var values = arr.map(function (el) {
+                return el.innerText.trim();
+            });
+            if (values.indexOf(el.innerText.trim()) < 0) arr.push(el);
+            return arr;
+        }, []).sort(function (a, b) {
+            var A = a.innerText.toLowerCase();
+            var B = b.innerText.toLowerCase();
+            if (!isNaN(Number(A)) && !isNaN(Number(B))) {
+                if (Number(A) < Number(B)) return -1;
+                if (Number(A) > Number(B)) return 1;
+            } else {
+                if (A < B) return -1;
+                if (A > B) return 1;
+            }
+            return 0;
+        }).map(function (td) {
+            return _this.dropdownFilterItem(td, self);
+        });
+        this.inputs = innerDivs.map(function (div) {
+            return div.firstElementChild;
+        });
+        var selectAllCheckboxDiv = this.dropdownFilterItemSelectAll();
+        this.selectAllCheckbox = selectAllCheckboxDiv.firstElementChild;
+        innerDivs.unshift(selectAllCheckboxDiv);
+        var searchFilterDiv = this.dropdownFilterSearch();
+        this.searchFilter = searchFilterDiv.firstElementChild;
+        var outerDiv = innerDivs.reduce(function (outerDiv, innerDiv) {
+            outerDiv.appendChild(innerDiv);
+            return outerDiv;
+        }, document.createElement('div'));
+        outerDiv.className = 'checkbox-container';
+        var elements = [];
+        if (this.options.sort) elements = elements.concat([this.dropdownFilterSort(this.options.captions.a_to_z), this.dropdownFilterSort(this.options.captions.z_to_a)]);
+        if (this.options.search) elements.push(searchFilterDiv);
+        return elements.concat(outerDiv).reduce(function (html, el) {
+            html.appendChild(el);
+            return html;
+        }, dropdownFilterContent);
+    };
+    FilterMenu.prototype.dropdownFilterDropdown = function () {
+        var dropdownFilterDropdown = document.createElement('div');
+        dropdownFilterDropdown.className = 'dropdown-filter-dropdown';
+        var arrow = document.createElement('span');
+        arrow.className = 'glyphicon glyphicon-arrow-down dropdown-filter-icon';
+        var icon = document.createElement('i');
+        icon.className = 'arrow-down';
+        arrow.appendChild(icon);
+        dropdownFilterDropdown.appendChild(arrow);
+        dropdownFilterDropdown.appendChild(this.dropdownFilterContent());
+        if ($(this.th).hasClass('no-sort')) {
+            $(dropdownFilterDropdown).find('.dropdown-filter-sort').remove();
+        }
+        if ($(this.th).hasClass('no-filter')) {
+            $(dropdownFilterDropdown).find('.checkbox-container').remove();
+        }
+        if ($(this.th).hasClass('no-search')) {
+            $(dropdownFilterDropdown).find('.dropdown-filter-search').remove();
+        }
+        if ($(this.th).hasClass('.disable-filter')) {
+            $(dropdownFilterDropdown).find('span').remove();
+        }
+        return dropdownFilterDropdown;
+    };
+    return FilterMenu;
+}();
+
+var FilterCollection = function () {
+    function FilterCollection(target, options) {
+        this.target = target;
+        this.options = options;
+        this.ths = target.find('th' + options.columnSelector).toArray();
+        this.filterMenus = this.ths.map(function (th, index) {
+            var column = $(th).index();
+            return new FilterMenu(target, th, column, index, options);
+        });
+        this.rows = target.find('tbody').find('tr').toArray();
+        this.table = target.get(0);
+    }
+    FilterCollection.prototype.initialize = function () {
+        this.filterMenus.forEach(function (filterMenu) {
+            filterMenu.initialize();
+        });
+        this.bindCheckboxes();
+        this.bindSelectAllCheckboxes();
+        this.bindSort();
+        this.bindSearch();
+    };
+    FilterCollection.prototype.bindCheckboxes = function () {
+        var filterMenus = this.filterMenus;
+        var rows = this.rows;
+        var ths = this.ths;
+        var updateRowVisibility = this.updateRowVisibility;
+        this.target.find('.dropdown-filter-menu-item.item').change(function () {
+            var index = $(this).data('index');
+            var value = $(this).val();
+            filterMenus[index].updateSelectAll();
+            updateRowVisibility(filterMenus, rows, ths);
+        });
+    };
+    FilterCollection.prototype.bindSelectAllCheckboxes = function () {
+        var filterMenus = this.filterMenus;
+        var rows = this.rows;
+        var ths = this.ths;
+        var updateRowVisibility = this.updateRowVisibility;
+        this.target.find('.dropdown-filter-menu-item.select-all').change(function () {
+            var index = $(this).data('index');
+            var value = this.checked;
+            filterMenus[index].selectAllUpdate(value);
+            updateRowVisibility(filterMenus, rows, ths);
+        });
+    };
+    FilterCollection.prototype.bindSort = function () {
+        var filterMenus = this.filterMenus;
+        var rows = this.rows;
+        var ths = this.ths;
+        var sort = this.sort;
+        var table = this.table;
+        var options = this.options;
+        var updateRowVisibility = this.updateRowVisibility;
+        this.target.find('.dropdown-filter-sort').click(function () {
+            var $sortElement = $(this).find('span');
+            var column = $sortElement.data('column');
+            var order = $sortElement.attr('class');
+            sort(column, order, table, options);
+            updateRowVisibility(filterMenus, rows, ths);
+        });
+    };
+    FilterCollection.prototype.bindSearch = function () {
+        var filterMenus = this.filterMenus;
+        var rows = this.rows;
+        var ths = this.ths;
+        var updateRowVisibility = this.updateRowVisibility;
+        this.target.find('.dropdown-filter-search').keyup(function () {
+            var $input = $(this).find('input');
+            var index = $input.data('index');
+            var value = $input.val();
+            filterMenus[index].searchToggle(value);
+            updateRowVisibility(filterMenus, rows, ths);
+        });
+    };
+    FilterCollection.prototype.updateRowVisibility = function (filterMenus, rows, ths) {
+        var showRows = rows;
+        var hideRows = [];
+        var selectedLists = filterMenus.map(function (filterMenu) {
+            return {
+                column: filterMenu.column,
+                selected: filterMenu.inputs.filter(function (input) {
+                    return input.checked;
+                }).map(function (input) {
+                    return input.value.trim().replace(/ +(?= )/g, '');
+                })
+            };
+        });
+        for (var i = 0; i < rows.length; i++) {
+            var tds = rows[i].children;
+            for (var j = 0; j < selectedLists.length; j++) {
+                var content = tds[selectedLists[j].column].innerText.trim().replace(/ +(?= )/g, '');
+                if (selectedLists[j].selected.indexOf(content) === -1) {
+                    $(rows[i]).hide();
+                    break;
+                }
+                $(rows[i]).show();
+            }
+        }
+    };
+    FilterCollection.prototype.sort = function (column, order, table, options) {
+        var flip = 1;
+        if (order === options.captions.z_to_a.toLowerCase().split(' ').join('-')) flip = -1;
+        var tbody = $(table).find('tbody').get(0);
+        var rows = $(tbody).find('tr').get();
+        rows.sort(function (a, b) {
+            var A = a.children[column].innerText.toUpperCase();
+            var B = b.children[column].innerText.toUpperCase();
+            if (!isNaN(Number(A)) && !isNaN(Number(B))) {
+                if (Number(A) < Number(B)) return -1 * flip;
+                if (Number(A) > Number(B)) return 1 * flip;
+            } else {
+                if (A < B) return -1 * flip;
+                if (A > B) return 1 * flip;
+            }
+            return 0;
+        });
+        for (var i = 0; i < rows.length; i++) {
+            tbody.appendChild(rows[i]);
+        }
+    };
+    return FilterCollection;
+}();
+
+$$1.fn.excelTableFilter = function (options) {
+    var target = this;
+    options = $$1.extend({}, $$1.fn.excelTableFilter.options, options);
+    if (typeof options.columnSelector === 'undefined') options.columnSelector = '';
+    if (typeof options.sort === 'undefined') options.sort = true;
+    if (typeof options.search === 'undefined') options.search = true;
+    if (typeof options.captions === 'undefined') options.captions = {
+        a_to_z: 'A to Z',
+        z_to_a: 'Z to A',
+        search: 'Search',
+        select_all: 'Select All'
+    };
+    var filterCollection = new FilterCollection(target, options);
+    filterCollection.initialize();
+    return target;
+};
+$$1.fn.excelTableFilter.options = {};
+
+}(jQuery));

--- a/src/SALsA_Function/HTMLTemplate/excel-bootstrap-table-filter-bundle/excel-bootstrap-table-filter-style.css
+++ b/src/SALsA_Function/HTMLTemplate/excel-bootstrap-table-filter-bundle/excel-bootstrap-table-filter-style.css
@@ -1,0 +1,78 @@
+.dropdown-filter-dropdown {
+    text-align: left;
+    font-size: 16px;
+    font-weight: normal;
+
+
+    display:inline-block;
+}
+
+.dropdown-filter-icon {
+    margin-left:5px;
+    line-height:1.3;
+    border:1px solid black;
+}
+
+
+.dropdown-filter-icon:hover {
+    cursor:pointer;
+}
+
+.checkbox-container {
+    max-height: 400px;
+    overflow-y: scroll;
+}
+.dropdown-filter-content {
+    display: none;
+    position: absolute;
+    background-color: #f9f9f9;
+    min-width: 200px;
+    box-shadow: 0px 8px 16px 0px rgba(0,0,0,0.2);
+    z-index: 1;
+    padding-bottom:5px;
+    padding-top:5px;
+    padding-right:5px;
+    padding-left:5px;
+}
+
+.dropdown-filter-content div {
+    margin-top:5px;
+    margin-left:5px;
+    margin-right:5px;
+    margin-bottom:5px;
+}
+
+.dropdown-filter-content div.dropdown-filter-search {
+    margin-bottom:10px;
+    margin-top:10px;
+}
+
+
+.dropdown-filter-content div.dropdown-filter-sort {
+    padding-top:5px;
+    padding-bottom:5px;
+}
+
+.dropdown-filter-content div.dropdown-filter-sort:hover {
+    background-color:#e1e5e7;
+    cursor:pointer;
+}
+
+.dropdown-filter-content div.dropdown-filter-sort span {
+    margin-right:5px;
+    margin-left:5px;
+    margin-top:5px;
+    margin-bottom:5px;
+    color:#000000;
+}
+
+.arrow-down {
+    border: solid black;
+    border-width: 0 3px 3px 0;
+    display: inline-block;
+    padding: 3px;
+    margin-right:5px;
+    margin-left:5px;
+    transform: rotate(45deg);
+    -webkit-transform: rotate(45deg);
+}

--- a/src/SALsA_Function/SALsA_Function.csproj
+++ b/src/SALsA_Function/SALsA_Function.csproj
@@ -35,6 +35,15 @@
     <Content Include="HTMLTemplate\Tools.html">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </Content>
+    <Content Include="HTMLTemplate\SALsAStatus.html">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </Content>
+    <Content Include="HTMLTemplate\excel-bootstrap-table-filter-bundle\excel-bootstrap-table-filter-bundle.js">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </Content>
+    <Content Include="HTMLTemplate\excel-bootstrap-table-filter-bundle\excel-bootstrap-table-filter-style.css">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </Content>
     <Content Include="..\..\access.txt">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </Content>


### PR DESCRIPTION
- Added excel like filters to the Status page
- Refactor Status page to pull data from Internal status instead of recreating everything
- Started moving some of the HTML centric functions to SALsA_Function instead of SALsA_exe
- Removed the style madness in each element of the HTML, and using a style tag instead
- Added an HTML template for Status page, to make changes easier

The filter script is a slightly modified version of https://github.com/chestercharles/excel-bootstrap-table-filter/
I manually reviewed the code, and added the MIT license to the folder.

Note : The filtering is very slow (1-2sec) and is not Async, but this is okay for now.
Note : We might want to add an argument like status?owningTeam="AZURERT\Extensions" and automatically filter based on that in the backend instead
Note : These are temporary, until we get a real front end

Without filter
![image](https://user-images.githubusercontent.com/5965677/102011253-102c2900-3d11-11eb-8c34-907f98c35d46.png)

After  filter
![image](https://user-images.githubusercontent.com/5965677/102011291-33ef6f00-3d11-11eb-8352-d64fa0afac3e.png)

Filter UI 
![image](https://user-images.githubusercontent.com/5965677/102011301-423d8b00-3d11-11eb-9e96-58cb034fff33.png)
